### PR TITLE
add explicit uselib=CRYPTO to wscript for cygwin compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var binding = require('./build/default/binding');
+var binding = require('./build/Release/binding');
 
 Buffer.prototype.toHex = function() {
   return binding.bufToHex(this);

--- a/wscript
+++ b/wscript
@@ -16,3 +16,4 @@ def build(bld):
   obj = bld.new_task_gen("cxx", "shlib", "node_addon")
   obj.target = "binding"
   obj.source = "./src/binding.cc"
+  obj.uselib = 'CRYPTO'


### PR DESCRIPTION
add explicit uselib=CRYPTO to wscript for cygwin compatibility: without node-waf fails to find the openssl symbols.
